### PR TITLE
Use resilient UI session storage with window fallback and expose helpers

### DIFF
--- a/src/bandcamp/content/app.svelte
+++ b/src/bandcamp/content/app.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 import { TreeData } from 'src/app/treeview/TreeData';
-import { currentPageUrl, sessionStorage } from 'src/core/shared';
+import { currentPageUrl } from 'src/core/shared';
 import { console } from 'src/utils/console';
 import { element } from 'src/utils/dom';
 import { onCtrlKey } from 'src/utils/keyboard';
 import { onMount } from 'svelte';
 import { BCXSidePanel, BCXTour } from '$lib/components/bcx';
 import BCXDrawerButton from '$lib/components/bcx/BCXDrawerButton.svelte';
-import { SIDE_PANEL_OPEN_KEY } from '../domain/storageKey';
 import {
   getSidePanelOpen,
   initUiState,
@@ -28,7 +27,9 @@ let sidePanelStateInitialized: boolean = $state(false);
 // Persist side panel state across page navigations (only after initial load)
 $effect(() => {
   if (sidePanelStateInitialized) {
-    sessionStorage.set({ [SIDE_PANEL_OPEN_KEY]: sidePanelOpen });
+    setSidePanelOpen(sidePanelOpen).catch((error) => {
+      console.warn('❌ BCX: Failed to persist side panel state:', error);
+    });
   }
 });
 

--- a/src/bandcamp/domain/ui/uiState.ts
+++ b/src/bandcamp/domain/ui/uiState.ts
@@ -1,26 +1,99 @@
 import { sessionStorage } from 'src/core/shared';
+import { console } from 'src/utils/console';
 import { SIDE_PANEL_OPEN_KEY } from '../storageKey';
 
 let initialized = false;
 let initPromise: Promise<void> | null = null;
 let sidePanelOpenCache: boolean | undefined;
+const WINDOW_SESSION_STORAGE_PREFIX = 'bcx';
+
+function windowSessionStorageKey(key: string) {
+  return `${WINDOW_SESSION_STORAGE_PREFIX}:${key}`;
+}
+
+function canUseExtensionSessionStorage() {
+  return (
+    typeof chrome !== 'undefined' &&
+    Boolean(chrome.runtime?.id) &&
+    Boolean(chrome.storage?.session)
+  );
+}
+
+function readWindowSessionBoolean(key: string): boolean | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  try {
+    const rawValue = window.sessionStorage.getItem(windowSessionStorageKey(key));
+    if (rawValue === null) return undefined;
+    return rawValue === 'true';
+  } catch (error) {
+    console.warn(`❌ BCX: Failed to read window sessionStorage key ${key}:`, error);
+    return undefined;
+  }
+}
+
+async function writeWindowSessionBoolean(
+  key: string,
+  value: boolean,
+): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  window.sessionStorage.setItem(windowSessionStorageKey(key), String(value));
+}
+
+export async function getUiSessionBoolean(
+  key: string,
+): Promise<boolean | undefined> {
+  if (canUseExtensionSessionStorage()) {
+    try {
+      return await sessionStorage.getByKey<boolean>(key);
+    } catch (error) {
+      console.warn(
+        `⚠️ BCX: Falling back to window sessionStorage read for key ${key}:`,
+        error,
+      );
+    }
+  }
+
+  return readWindowSessionBoolean(key);
+}
+
+export async function setUiSessionBoolean(
+  key: string,
+  value: boolean,
+): Promise<void> {
+  if (canUseExtensionSessionStorage()) {
+    try {
+      await chrome.storage.session.set({ [key]: value });
+      return;
+    } catch (error) {
+      console.warn(
+        `⚠️ BCX: Falling back to window sessionStorage write for key ${key}:`,
+        error,
+      );
+    }
+  }
+
+  await writeWindowSessionBoolean(key, value);
+}
 
 export async function initUiState(): Promise<void> {
   if (initialized) return;
   if (initPromise) return initPromise;
 
   initPromise = (async () => {
-    sidePanelOpenCache =
-      await sessionStorage.getByKey<boolean>(SIDE_PANEL_OPEN_KEY);
+    sidePanelOpenCache = await getUiSessionBoolean(SIDE_PANEL_OPEN_KEY);
 
-    chrome.storage.onChanged.addListener((changes, areaName) => {
-      if (areaName !== 'session') return;
+    if (canUseExtensionSessionStorage()) {
+      chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (areaName !== 'session') return;
 
-      const change = changes[SIDE_PANEL_OPEN_KEY];
-      if (!change) return;
+        const change = changes[SIDE_PANEL_OPEN_KEY];
+        if (!change) return;
 
-      sidePanelOpenCache = change.newValue as boolean | undefined;
-    });
+        sidePanelOpenCache = change.newValue as boolean | undefined;
+      });
+    }
 
     initialized = true;
   })();
@@ -36,5 +109,5 @@ export async function setSidePanelOpen(value: boolean): Promise<void> {
   if (sidePanelOpenCache === value) return;
 
   sidePanelOpenCache = value;
-  await chrome.storage.session.set({ [SIDE_PANEL_OPEN_KEY]: value });
+  await setUiSessionBoolean(SIDE_PANEL_OPEN_KEY, value);
 }

--- a/src/lib/components/bcx/BCXTour.svelte
+++ b/src/lib/components/bcx/BCXTour.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 import { TOUR_COMPLETE_KEY } from 'src/bandcamp/domain/storageKey';
-import { sessionStorage } from 'src/core/shared';
+import {
+  getUiSessionBoolean,
+  setUiSessionBoolean,
+} from 'src/bandcamp/domain/ui/uiState';
 import { console } from 'src/utils/console';
 import { onMount } from 'svelte';
 
@@ -37,8 +40,7 @@ onMount(async () => {
   if (!autoStart) return;
 
   try {
-    const hasCompleted =
-      await sessionStorage.getByKey<boolean>(TOUR_COMPLETE_KEY);
+    const hasCompleted = await getUiSessionBoolean(TOUR_COMPLETE_KEY);
     if (!hasCompleted && steps.length > 0) {
       setTimeout(() => {
         startTour();
@@ -247,7 +249,7 @@ async function completeTour() {
   cleanupHighlight();
 
   try {
-    await sessionStorage.set({ [TOUR_COMPLETE_KEY]: true });
+    await setUiSessionBoolean(TOUR_COMPLETE_KEY, true);
     isActive = false;
     isCompleted = true;
     currentStepIndex = -1;
@@ -266,7 +268,9 @@ function skipTour() {
 }
 
 function resetTour() {
-  sessionStorage.set({ [TOUR_COMPLETE_KEY]: false });
+  setUiSessionBoolean(TOUR_COMPLETE_KEY, false).catch((error) => {
+    console.warn('❌ BCX: Failed to reset tour completion state:', error);
+  });
   isCompleted = false;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure UI session state (side panel open, tour completion) is persisted reliably across environments by supporting the extension `chrome.storage.session` when available and falling back to `window.sessionStorage` otherwise.

### Description
- Added `getUiSessionBoolean` and `setUiSessionBoolean` helpers in `src/bandcamp/domain/ui/uiState.ts` that abstract between `chrome.storage.session` and `window.sessionStorage` and add a window-key prefix.
- Introduced defensive checks with `canUseExtensionSessionStorage`, and added safe read/write helpers with console warnings on failures.
- Updated `initUiState`, `getSidePanelOpen`, and `setSidePanelOpen` to use the new helpers and only attach `chrome.storage.onChanged` when extension session storage is available.
- Replaced direct `sessionStorage` usage in `src/bandcamp/content/app.svelte` and `src/lib/components/bcx/BCXTour.svelte` with the new API and added error handling/logging around persistence operations.

### Testing
- Ran type-check and build (`npm run build`) which completed successfully. 
- Executed the test suite (`npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2bc8325488330a51ad119ebb05fc1)