### PR TITLE
Add MainTreeData two-level cache and integrate into tree creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ To learn more about Rsbuild, check out the following resources:
 
 - [Rsbuild documentation](https://rsbuild.rs) - explore Rsbuild features and APIs.
 - [Rsbuild GitHub repository](https://github.com/web-infra-dev/rsbuild) - your feedback and contributions are welcome!
+
+## Architecture Notes
+
+- Main tree caching strategy: `docs/architecture/main-tree-data-cache.md`

--- a/docs/architecture/main-tree-data-cache.md
+++ b/docs/architecture/main-tree-data-cache.md
@@ -1,0 +1,94 @@
+# MainTreeData caching proposal
+
+## Why cache `MainTreeData`
+
+`MainTreeData.create(...)` builds the full side-panel tree and runs multiple async loaders (`FollowingBands`, `FollowingGenres`, `Collection`, `Wishlist`, `History`). Even when some loaders already read from storage, rebuilding the whole tree object can still be expensive and duplicated in the same tab/session.
+
+## Recommended approach: two-level cache
+
+Use a **memory-first + storage-backed** cache:
+
+1. **Level 1 (in-memory, fast path)**
+   - Keep a `Map<string, CacheEntry>` in the content script process.
+   - Key should include:
+     - `url.uuid` (or full URL)
+     - `band?.id`
+     - `album?.id`
+     - `fan_id` from `bandcampPageData`
+     - schema version (`v1`, `v2`, ...)
+   - Store `{ treeDataLike, createdAt }`.
+
+2. **Level 2 (chrome.storage.local/session, warm path)**
+   - Persist **serializable tree snapshot** only (labels, hrefs, image, keywords, nested children).
+   - Do not persist non-serializable fields (`onClick`, component `icon`, function handlers).
+   - Rehydrate runtime-only fields when restoring from snapshot.
+
+## Suggested key format
+
+```text
+/ui/main-tree-cache/v2/{fan_id}/{url_uuid}/{band_id || 0}/{album_id || 0}
+```
+
+This avoids collisions across users/pages and lets you invalidate by version.
+
+## Revalidation policy
+
+Use **stale-while-revalidate**:
+
+- If cached entry is **fresh**: render it immediately.
+- Then revalidate in background and replace if changed.
+
+Suggested TTLs by subtree:
+
+- `History`: 5–15 minutes (changes frequently)
+- `FollowingBands` / `FollowingGenres`: 30–60 minutes
+- `Collection` / `Wishlist`: 10–30 minutes
+- `Band` / `Album` page metadata: 24 hours (or until page URL changes)
+
+For a single whole-tree TTL, start with **15 minutes**.
+
+## Hard revalidation triggers
+
+Always bypass cache when:
+
+1. User clicks any explicit refresh action (`Refresh Collection`, `Refresh Following Bands`, etc.).
+2. `fan_id` changes (user switched account/login).
+3. Extension version changes (schema mismatch).
+4. URL identity changes (`url.uuid` changed).
+5. Loader errors occurred on previous snapshot (mark snapshot as degraded).
+
+## Invalidation mechanics
+
+- Store metadata alongside snapshot:
+  - `createdAt`, `expiresAt`, `schemaVersion`, `sourceVersion`
+- On read:
+  - reject if `schemaVersion` mismatch
+  - treat as stale if `Date.now() > expiresAt`
+- On write:
+  - update atomically with metadata and payload
+
+## Minimal implementation shape
+
+```ts
+interface MainTreeCacheEntry {
+  key: string;
+  createdAt: number;
+  expiresAt: number;
+  schemaVersion: number;
+  payload: MainTreeSnapshot;
+}
+```
+
+`MainTreeSnapshot` should be a serializable tree model (no functions/components).
+
+## Where to integrate
+
+A practical integration point is around `MainTreeData.create(...)` call site in `src/bandcamp/content/app.ts`:
+
+1. Build cache key from current page + entities.
+2. Try memory cache.
+3. Fallback to storage cache.
+4. Render cached snapshot quickly.
+5. Rebuild using current loaders and replace if changed.
+6. Persist updated snapshot.
+

--- a/src/app/treeview/items/MainTreeData.ts
+++ b/src/app/treeview/items/MainTreeData.ts
@@ -12,9 +12,26 @@ import { FollowingBandsTreeItem } from './FollowingBandsTreeItem';
 import { FollowingGenresTreeItem } from './FollowingGenresTreeItem';
 import { HistoryTreeItem } from './HistoryTreeItem';
 import { WishlistTreeItem } from './WishlistTreeItem';
+import { MainTreeDataCache } from './MainTreeDataCache';
 
 export class MainTreeData {
   static async create(
+    url: Url,
+    band: Band | null,
+    album: Album | null,
+  ): Promise<TreeData> {
+    const cacheKey = MainTreeDataCache.buildKey(url, band, album);
+    const cachedTreeData = await MainTreeDataCache.get(cacheKey);
+    if (cachedTreeData) {
+      return cachedTreeData;
+    }
+
+    const treeData = await this.createFresh(url, band, album);
+    await MainTreeDataCache.set(cacheKey, treeData);
+    return treeData;
+  }
+
+  private static async createFresh(
     url: Url,
     band: Band | null,
     album: Album | null,

--- a/src/app/treeview/items/MainTreeData.ts
+++ b/src/app/treeview/items/MainTreeData.ts
@@ -11,8 +11,8 @@ import { FanPageDataTreeItem } from './FanPageDataTreeItem';
 import { FollowingBandsTreeItem } from './FollowingBandsTreeItem';
 import { FollowingGenresTreeItem } from './FollowingGenresTreeItem';
 import { HistoryTreeItem } from './HistoryTreeItem';
-import { WishlistTreeItem } from './WishlistTreeItem';
 import { MainTreeDataCache } from './MainTreeDataCache';
+import { WishlistTreeItem } from './WishlistTreeItem';
 
 export class MainTreeData {
   static async create(
@@ -20,14 +20,22 @@ export class MainTreeData {
     band: Band | null,
     album: Album | null,
   ): Promise<TreeData> {
+    const logLabel = `[MainTreeData.create]`;
+    console.log(logLabel, { url, band, album });
+    console.time(logLabel);
+
     const cacheKey = MainTreeDataCache.buildKey(url, band, album);
     const cachedTreeData = await MainTreeDataCache.get(cacheKey);
     if (cachedTreeData) {
+      console.timeEnd(logLabel);
       return cachedTreeData;
     }
 
     const treeData = await this.createFresh(url, band, album);
     await MainTreeDataCache.set(cacheKey, treeData);
+
+    console.timeEnd(logLabel);
+
     return treeData;
   }
 
@@ -36,7 +44,7 @@ export class MainTreeData {
     band: Band | null,
     album: Album | null,
   ): Promise<TreeData> {
-    const logLabel = `[MainTreeData.create]`;
+    const logLabel = `[MainTreeData.createFresh]`;
     console.log(logLabel, { url, band, album });
     console.time(logLabel);
 

--- a/src/app/treeview/items/MainTreeDataCache.ts
+++ b/src/app/treeview/items/MainTreeDataCache.ts
@@ -4,6 +4,7 @@ import { bandcampPageData } from 'src/bandcamp/domain/shared';
 import { sessionStorage } from 'src/core/shared';
 import type { Url } from 'src/core/url';
 import { console } from 'src/utils/console';
+import { ExternalLink, Funnel } from '@lucide/svelte';
 import { TreeData } from '../TreeData';
 import type { TreeItem } from '../TreeItem';
 import type { TreeItemButton } from '../TreeItemButton';
@@ -28,6 +29,7 @@ interface TreeItemSnapshot {
   image?: string;
   query?: string;
   keywords?: string[];
+  iconKey?: string;
   buttons?: TreeItemButtonSnapshot[];
 }
 
@@ -146,6 +148,7 @@ function serializeTreeItem(item: TreeItem): TreeItemSnapshot {
     image: item.image,
     query: item.query,
     keywords: item.keywords,
+    iconKey: getIconKey(item.icon),
     buttons: buttons.length > 0 ? buttons : undefined,
     children: item.children?.map(serializeTreeItem),
   };
@@ -168,7 +171,31 @@ function deserializeTreeItem(item: TreeItemSnapshot): TreeItem {
     image: item.image,
     query: item.query,
     keywords: item.keywords,
+    icon: getIconFromKey(item.iconKey),
     buttons,
     children: item.children?.map(deserializeTreeItem),
   };
+}
+
+function getIconKey(icon: any): string | undefined {
+  if (icon === ExternalLink) {
+    return 'external-link';
+  }
+
+  if (icon === Funnel) {
+    return 'funnel';
+  }
+
+  return undefined;
+}
+
+function getIconFromKey(iconKey?: string): any {
+  switch (iconKey) {
+    case 'external-link':
+      return ExternalLink;
+    case 'funnel':
+      return Funnel;
+    default:
+      return undefined;
+  }
 }

--- a/src/app/treeview/items/MainTreeDataCache.ts
+++ b/src/app/treeview/items/MainTreeDataCache.ts
@@ -1,0 +1,174 @@
+import type { Album } from 'src/bandcamp/domain/album/album';
+import type { Band } from 'src/bandcamp/domain/band/band';
+import { bandcampPageData } from 'src/bandcamp/domain/shared';
+import { sessionStorage } from 'src/core/shared';
+import type { Url } from 'src/core/url';
+import { console } from 'src/utils/console';
+import { TreeData } from '../TreeData';
+import type { TreeItem } from '../TreeItem';
+import type { TreeItemButton } from '../TreeItemButton';
+
+const CACHE_VERSION = 1;
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const CACHE_KEY_PREFIX = '/ui/main-tree-cache';
+
+interface TreeItemButtonSnapshot {
+  title: string;
+  href?: string;
+}
+
+interface TreeItemSnapshot {
+  id?: string;
+  label?: string;
+  children?: TreeItemSnapshot[];
+  open?: boolean;
+  level?: number;
+  path?: string;
+  href?: string;
+  image?: string;
+  query?: string;
+  keywords?: string[];
+  buttons?: TreeItemButtonSnapshot[];
+}
+
+interface MainTreeSnapshot {
+  createdAt: number;
+  expiresAt: number;
+  version: number;
+  items: TreeItemSnapshot[];
+}
+
+type CacheLayer = 'memory' | 'session';
+
+const memoryCache = new Map<string, MainTreeSnapshot>();
+
+export class MainTreeDataCache {
+  static buildKey(url: Url, band: Band | null, album: Album | null): string {
+    const fanId = bandcampPageData?.fanData?.fan_id ?? 0;
+    const bandId = band?.id ?? 0;
+    const albumId = album?.id ?? 0;
+    return `${CACHE_KEY_PREFIX}/v${CACHE_VERSION}/${fanId}/${url.uuid}/${bandId}/${albumId}`;
+  }
+
+  static async get(key: string): Promise<TreeData | null> {
+    const logLabel = '[MainTreeDataCache.get]';
+    console.time(logLabel);
+    const cacheResult = await this.getSnapshot(key);
+    if (!cacheResult) {
+      console.timeEnd(logLabel);
+      console.log(logLabel, 'MISS', { key });
+      return null;
+    }
+
+    const treeData = new TreeData(cacheResult.snapshot.items.map(deserializeTreeItem));
+    console.timeEnd(logLabel);
+    console.log(logLabel, 'HIT', {
+      key,
+      layer: cacheResult.layer,
+      createdAt: cacheResult.snapshot.createdAt,
+      expiresAt: cacheResult.snapshot.expiresAt,
+      items: cacheResult.snapshot.items.length,
+    });
+    return treeData;
+  }
+
+  static async set(key: string, treeData: TreeData): Promise<void> {
+    const now = Date.now();
+    const snapshot: MainTreeSnapshot = {
+      createdAt: now,
+      expiresAt: now + CACHE_TTL_MS,
+      version: CACHE_VERSION,
+      items: treeData.items.map(serializeTreeItem),
+    };
+
+    memoryCache.set(key, snapshot);
+    await sessionStorage.setByKey(key, snapshot);
+  }
+
+  static async invalidateAll(): Promise<void> {
+    memoryCache.clear();
+    const keys = await sessionStorage.getKeys();
+    const cacheKeys = keys.filter((key) => key.startsWith(CACHE_KEY_PREFIX));
+    if (cacheKeys.length === 0) {
+      return;
+    }
+
+    await sessionStorage.remove(cacheKeys);
+    console.log('[MainTreeDataCache.invalidateAll]', cacheKeys.length);
+  }
+
+  private static async getSnapshot(
+    key: string,
+  ): Promise<{ snapshot: MainTreeSnapshot; layer: CacheLayer } | null> {
+    const now = Date.now();
+    const memorySnapshot = memoryCache.get(key);
+    if (memorySnapshot) {
+      if (this.isFresh(memorySnapshot, now)) {
+        return { snapshot: memorySnapshot, layer: 'memory' };
+      }
+      memoryCache.delete(key);
+    }
+
+    const sessionSnapshot = await sessionStorage.getByKey<MainTreeSnapshot>(key);
+    if (!sessionSnapshot) {
+      return null;
+    }
+
+    if (!this.isFresh(sessionSnapshot, now)) {
+      await sessionStorage.remove(key);
+      return null;
+    }
+
+    memoryCache.set(key, sessionSnapshot);
+    return { snapshot: sessionSnapshot, layer: 'session' };
+  }
+
+  private static isFresh(snapshot: MainTreeSnapshot, now: number): boolean {
+    return snapshot.version === CACHE_VERSION && now <= snapshot.expiresAt;
+  }
+}
+
+function serializeTreeItem(item: TreeItem): TreeItemSnapshot {
+  const buttons = (item.buttons || [])
+    .filter((button) => !!button.href)
+    .map((button) => ({
+      title: button.title,
+      href: button.href,
+    }));
+
+  return {
+    id: item.id,
+    label: item.label,
+    open: item.open,
+    level: item.level,
+    path: item.path,
+    href: item.href,
+    image: item.image,
+    query: item.query,
+    keywords: item.keywords,
+    buttons: buttons.length > 0 ? buttons : undefined,
+    children: item.children?.map(serializeTreeItem),
+  };
+}
+
+function deserializeTreeItem(item: TreeItemSnapshot): TreeItem {
+  const buttons: TreeItemButton[] | undefined = item.buttons?.map((button) => ({
+    title: button.title,
+    icon: undefined,
+    href: button.href,
+  }));
+
+  return {
+    id: item.id,
+    label: item.label,
+    open: item.open,
+    level: item.level,
+    path: item.path,
+    href: item.href,
+    image: item.image,
+    query: item.query,
+    keywords: item.keywords,
+    buttons,
+    children: item.children?.map(deserializeTreeItem),
+  };
+}

--- a/src/app/treeview/utils.ts
+++ b/src/app/treeview/utils.ts
@@ -1,5 +1,6 @@
 import { Funnel } from '@lucide/svelte';
 import { createQueryCountString } from 'src/bandcamp/domain/page/helper';
+import { MainTreeDataCache } from './items/MainTreeDataCache';
 import type { TreeItem } from './TreeItem';
 
 export function isNode(item: TreeItem): boolean {
@@ -177,6 +178,7 @@ export function createLoadHandler<T>(fetchData: () => Promise<T[]>) {
 
     try {
       const data = await fetchData();
+      await MainTreeDataCache.invalidateAll();
 
       // Hardcoded string format using the array's length
       element.textContent = `Loaded ${data.length} items`;


### PR DESCRIPTION
### Motivation

- Rebuilds of the main side-panel tree (`MainTreeData.create`) are relatively expensive and can be duplicated within the same tab/session, so a fast cache can improve responsiveness.
- Persisting a serializable snapshot across sessions allows warm starts while avoiding storing runtime-only fields like handlers or components.
- Provide a clear architecture note for the chosen caching approach and key format.

### Description

- Added a new `MainTreeDataCache` implementing a two-level cache (in-memory `Map` + `sessionStorage`) with TTL, versioning, snapshot serialization, deserialization, and an `invalidateAll` helper under `src/app/treeview/items/MainTreeDataCache.ts`.
- Integrated caching into `MainTreeData.create` by attempting to read from the cache first, falling back to a new `createFresh` path when a miss occurs, and persisting snapshots after building the fresh tree.
- Added serialization helpers that strip non-serializable/runtime-only fields (e.g. function handlers, icons) and rehydrate tree items with minimal runtime fields on cache restore.
- Added automatic cache invalidation call in `createLoadHandler` so dynamic loader actions flush cached snapshots after reloading data, and added a short architecture note and link in `README.md` plus a dedicated `docs/architecture/main-tree-data-cache.md` describing key format, TTLs, revalidation, and integration guidance.

### Testing

- Ran the repository test suite with `pnpm test` and the tests completed successfully with no changes required to existing tests.
- No new automated tests were added for caching in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d41aae48e8833084c2171ba5cd36eb)