### PR TITLE
Handle Enter key behavior for BCX tree nodes

### DIFF
--- a/src/lib/components/bcx/BcxTreeView.svelte
+++ b/src/lib/components/bcx/BcxTreeView.svelte
@@ -215,6 +215,25 @@ function handleKeyDown(event: KeyboardEvent) {
       break;
 
     case 'Enter':
+      if (currentIndex >= 0) {
+        const currentItem = effectiveTreeData.findVisible(currentIndex);
+
+        if (!currentItem) {
+          break;
+        }
+
+        if (isNode(currentItem) && !currentItem.href) {
+          if (isNodeExpanded(currentItem)) {
+            collapseNode(currentItem);
+          } else {
+            expandNode(currentItem);
+          }
+        } else {
+          handleItemClick(currentItem, event);
+        }
+      }
+      break;
+
     case ' ':
       handleItemClick(effectiveTreeData.findVisible(currentIndex), event);
       break;


### PR DESCRIPTION
### Motivation
- Make keyboard interaction more intuitive by having Enter toggle expansion for tree items with children, while preserving Enter-as-link behavior when an item has an `href`.
- Preserve existing Space key behavior which continues to trigger the item click handler.

### Description
- Updated `handleKeyDown` in `src/lib/components/bcx/BcxTreeView.svelte` to special-case the `Enter` key so it toggles expand/collapse for node items (`isNode(currentItem)`) that do not have an `href`.
- If the focused item has an `href`, `Enter` defers to the existing `handleItemClick` logic to perform navigation instead of toggling the node.
- Left the `Space` key handling unchanged so it still calls `handleItemClick` for the focused item.

### Testing
- Ran `npm run check -- src/lib/components/bcx/BcxTreeView.svelte`, which failed due to a Biome CLI/config schema mismatch in the environment and not related to this change.
- Ran `npm run svelte-check`, which reported pre-existing project-wide TypeScript and missing-dependency errors (e.g., missing `@lucide/svelte` typings), so those failures are unrelated to the change in this file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95cda033083308605a0c95dd3c1fb)