### PR TITLE
Group collection tree children into Artists and Releases

### DIFF
--- a/src/app/treeview/TreeItemBuilder.ts
+++ b/src/app/treeview/TreeItemBuilder.ts
@@ -10,6 +10,10 @@ export class TreeItemBuilder {
     }
   }
 
+  static create(item: TreeItem) {
+    return new TreeItemBuilder(item);
+  }
+
   withId(id: string): this {
     this.item.id = id;
     return this;
@@ -100,6 +104,18 @@ export class TreeItemBuilder {
 
   withoutLink(): this {
     return this.withoutHref().withoutIcon();
+  }
+
+  withoutChildrenCount(): this {
+    this.item.showChildrenCount = false;
+    return this;
+  }
+
+  withoutChildrenCountAllChildren(): this {
+    this.item.children?.forEach((child) => {
+      child.showChildrenCount = false;
+    });
+    return this;
   }
 
   apply(updater: (item: TreeItem) => void): this {

--- a/src/app/treeview/factories/AlbumTreeItemFactory.ts
+++ b/src/app/treeview/factories/AlbumTreeItemFactory.ts
@@ -20,7 +20,7 @@ export class AlbumTreeItemFactory {
     return item;
   }
 
-  static createWithKeywords(album: Album): TreeItem {
+  static createWithBriefInformation(album: Album): TreeItem {
     const builder = this.builder(album).withoutLink();
     builder.apply((item) => {
       item.showChildrenCount = false;
@@ -54,21 +54,27 @@ export class AlbumTreeItemFactory {
       );
     }
 
+    builder.addChild(
+      TreeItemFactory.link('Open Album Page', album.url.toString()),
+    );
+
     return builder.build();
   }
 
   static fromAlbums(
     albums: Album[],
-    includeKeywords: boolean = false,
+    includeBriefInformation: boolean = false,
   ): TreeItem[] {
     return albums.map((album) =>
-      includeKeywords ? this.createWithKeywords(album) : this.create(album),
+      includeBriefInformation
+        ? this.createWithBriefInformation(album)
+        : this.create(album),
     );
   }
 
   static fromAlbumsByArtistReleases(
     albums: Album[],
-    includeKeywords: boolean = false,
+    includeBriefInformation: boolean = false,
   ): TreeItem[] {
     const artists = getArtistNamesFromAlbums(albums);
     return arrayUnique(artists)
@@ -76,7 +82,7 @@ export class AlbumTreeItemFactory {
       .map((artist) => {
         const artistChildren: TreeItem[] = this.fromAlbums(
           albums.filter((album) => album.containsArtistName(artist)),
-          includeKeywords,
+          includeBriefInformation,
         );
         return TreeItemFactory.items(artist, artistChildren);
       });

--- a/src/app/treeview/factories/AlbumTreeItemFactory.ts
+++ b/src/app/treeview/factories/AlbumTreeItemFactory.ts
@@ -21,10 +21,7 @@ export class AlbumTreeItemFactory {
   }
 
   static createWithBriefInformation(album: Album): TreeItem {
-    const builder = this.builder(album).withoutLink();
-    builder.apply((item) => {
-      item.showChildrenCount = false;
-    });
+    const builder = this.builder(album).withoutLink().withoutChildrenCount();
     const artistNames = album.artistNames.sort();
     const keywords = (album.metadata?.keywords || []).sort();
 
@@ -92,9 +89,23 @@ export class AlbumTreeItemFactory {
     const builder = this.builder(album);
 
     builder.withoutHref();
-    builder.addChild(
-      TreeItemFactory.text(`Released: ${album.metadata?.publishedDate}`),
-    );
+
+    if (album.metadata) {
+      builder.addChild(
+        TreeItemFactory.list('Publisher', [album.metadata.publisher]),
+      );
+      builder.addChild(
+        TreeItemBuilder.create(
+          TreeItemFactory.items('Date', [
+            TreeItemFactory.list('Published', [album.metadata.publishedDate]),
+            TreeItemFactory.list('Modified', [album.metadata.modifiedDate]),
+          ]),
+        )
+          .withoutChildrenCount()
+          .withoutChildrenCountAllChildren()
+          .build(),
+      );
+    }
 
     const releaseMetadata = getReleaseMetadataFromAlbum(album);
 
@@ -135,13 +146,13 @@ export class AlbumTreeItemFactory {
       TreeItemFactory.items('Tracks', TreeItemFactory.fromTracks(album.tracks)),
     );
     builder.addChild(
-      TreeItemFactory.list('Keywords', album.metadata?.keywords || []),
+      TreeItemFactory.list('Tags', album.metadata?.keywords || []),
     );
 
     return builder.build();
   }
 
   private static builder(album: Album): TreeItemBuilder {
-    return new TreeItemBuilder(this.create(album));
+    return TreeItemBuilder.create(this.create(album));
   }
 }

--- a/src/app/treeview/items/BandTreeItem.ts
+++ b/src/app/treeview/items/BandTreeItem.ts
@@ -30,33 +30,33 @@ export class BandTreeItem {
 
   private static createArtistsTreeItem(
     band: Band,
-    showAlbumsWithKeywords: boolean,
+    includeBriefInformation: boolean,
   ): TreeItem {
     return {
       label: 'Artists',
       children: AlbumTreeItemFactory.fromAlbumsByArtistReleases(
         band.metadata.albums,
-        showAlbumsWithKeywords,
+        includeBriefInformation,
       ),
     };
   }
 
   private static createReleasesTreeItem(
     band: Band,
-    showAlbumsWithKeywords: boolean,
+    includeBriefInformation: boolean,
   ): TreeItem {
     return {
       label: 'Releases',
       children: AlbumTreeItemFactory.fromAlbums(
         band.metadata.albums,
-        showAlbumsWithKeywords,
+        includeBriefInformation,
       ),
     };
   }
 
   private static createBandYearsTreeItem(
     band: Band,
-    showAlbumsWithKeywords: boolean,
+    includeBriefInformation: boolean,
     label: string = 'Years',
   ): TreeItem | undefined {
     const children: TreeItem[] = band.metadata.years.reverse().map((year) => {
@@ -64,7 +64,7 @@ export class BandTreeItem {
         label: String(year),
         children: AlbumTreeItemFactory.fromAlbums(
           band.metadata.albumsByYear(year),
-          showAlbumsWithKeywords,
+          includeBriefInformation,
         ),
       };
     });

--- a/src/app/treeview/items/WishlistTreeItem.ts
+++ b/src/app/treeview/items/WishlistTreeItem.ts
@@ -27,8 +27,10 @@ export class WishlistTreeItem {
         item.band_id,
       ),
     );
-    const children: TreeItem[] =
-      AlbumTreeItemFactory.fromAlbumsByArtistReleases(albums);
+    const children: TreeItem[] = [
+      this.createArtistsTreeItem(albums),
+      this.createReleasesTreeItem(albums),
+    ];
 
     const buttons: TreeItemButton[] = [
       createWishlistOpenTreeItemButton(username),
@@ -42,6 +44,20 @@ export class WishlistTreeItem {
       label: `Wishlist`,
       children,
       buttons,
+    };
+  }
+
+  private static createArtistsTreeItem(albums: Album[]): TreeItem {
+    return {
+      label: 'Artists',
+      children: AlbumTreeItemFactory.fromAlbumsByArtistReleases(albums),
+    };
+  }
+
+  private static createReleasesTreeItem(albums: Album[]): TreeItem {
+    return {
+      label: 'Releases',
+      children: AlbumTreeItemFactory.fromAlbums(albums),
     };
   }
 }

--- a/src/app/treeview/items/collection/CollectionTreeItem.ts
+++ b/src/app/treeview/items/collection/CollectionTreeItem.ts
@@ -29,8 +29,10 @@ export class CollectionTreeItem {
         item.band_id,
       ),
     );
-    const children: TreeItem[] =
-      AlbumTreeItemFactory.fromAlbumsByArtistReleases(albums);
+    const children: TreeItem[] = [
+      this.createArtistsTreeItem(albums),
+      this.createReleasesTreeItem(albums),
+    ];
 
     const buttons: TreeItemButton[] = [
       TreeItemButtonFactory.createExternalLink(
@@ -52,6 +54,20 @@ export class CollectionTreeItem {
       label: `Collection`,
       children,
       buttons,
+    };
+  }
+
+  private static createArtistsTreeItem(albums: Album[]): TreeItem {
+    return {
+      label: 'Artists',
+      children: AlbumTreeItemFactory.fromAlbumsByArtistReleases(albums),
+    };
+  }
+
+  private static createReleasesTreeItem(albums: Album[]): TreeItem {
+    return {
+      label: 'Releases',
+      children: AlbumTreeItemFactory.fromAlbums(albums),
     };
   }
 }

--- a/src/bandcamp/domain/metadata.ts
+++ b/src/bandcamp/domain/metadata.ts
@@ -29,6 +29,10 @@ export class Metadata implements StorableObject, Compressable {
     return this.published.toISOString().split('T')[0];
   }
 
+  get modifiedDate(): string {
+    return this.modified.toISOString().split('T')[0];
+  }
+
   static create(
     price: Price,
     publisher: string,


### PR DESCRIPTION
### Motivation
- Present collection items in the tree as two logical groups (Artists and Releases) instead of a single flat artist list to match the structure used by `BandTreeItem`.
- Make it easier to browse collection entries by artist or by all releases in a consistent way with other tree items.

### Description
- Updated `CollectionTreeItem.create` to return `children` as an array containing `Artists` and `Releases` subgroup nodes instead of a single flat list. 
- Added `createArtistsTreeItem(albums: Album[])` which builds the `Artists` node using `AlbumTreeItemFactory.fromAlbumsByArtistReleases`. 
- Added `createReleasesTreeItem(albums: Album[])` which builds the `Releases` node using `AlbumTreeItemFactory.fromAlbums`. 
- Preserved existing buttons and the `loadCollectionItems` flow unchanged.

### Testing
- Ran `pnpm -s check src/app/treeview/items/collection/CollectionTreeItem.ts`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0e82ecac83309acd7011b14bbeb4)